### PR TITLE
Switch extension to MV2 event page

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,23 +1,40 @@
-const updateHeaders = (details) => {
-  return new Promise((resolve) => {
-    chrome.storage.sync.get(['allowOrigin'], ({ allowOrigin }) => {
-      if (!allowOrigin) {
-        return resolve({});
-      }
-      const responseHeaders = details.responseHeaders || [];
-      const headerIndex = responseHeaders.findIndex(h => h.name.toLowerCase() === 'access-control-allow-origin');
-      if (headerIndex >= 0) {
-        responseHeaders[headerIndex].value = allowOrigin;
-      } else {
-        responseHeaders.push({ name: 'Access-Control-Allow-Origin', value: allowOrigin });
-      }
-      resolve({ responseHeaders });
-    });
-  });
-};
+let allowOrigin = '';
+
+// Load the stored origin value when the extension starts
+chrome.storage.sync.get('allowOrigin', ({ allowOrigin: saved }) => {
+  if (saved) {
+    allowOrigin = saved;
+  }
+});
+
+// Update the cached value whenever the setting changes
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'sync' && changes.allowOrigin) {
+    allowOrigin = changes.allowOrigin.newValue || '';
+  }
+});
+
+function modifyHeaders(details) {
+  if (!allowOrigin) {
+    return {};
+  }
+
+  const responseHeaders = details.responseHeaders || [];
+  const headerIndex = responseHeaders.findIndex(
+    h => h.name.toLowerCase() === 'access-control-allow-origin'
+  );
+
+  if (headerIndex >= 0) {
+    responseHeaders[headerIndex].value = allowOrigin;
+  } else {
+    responseHeaders.push({ name: 'Access-Control-Allow-Origin', value: allowOrigin });
+  }
+
+  return { responseHeaders };
+}
 
 chrome.webRequest.onHeadersReceived.addListener(
-  (details) => updateHeaders(details),
+  modifyHeaders,
   { urls: ['<all_urls>'] },
   ['blocking', 'responseHeaders', 'extraHeaders']
 );

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "CORS Allow",
   "version": "1.0",
   "description": "Allow CORS for specified URL.",
@@ -9,13 +9,11 @@
     "webRequestBlocking",
     "<all_urls>"
   ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
   "background": {
-    "service_worker": "background.js"
+    "scripts": ["background.js"],
+    "persistent": false
   },
-  "action": {
+  "browser_action": {
     "default_popup": "popup.html",
     "default_title": "CORS Allow"
   }


### PR DESCRIPTION
## Summary
- convert manifest to manifest_version 2
- use background scripts for MV2 event pages
- adapt background.js for event pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68492bc90384832aa500d513285cacb3