### PR TITLE
fix manifest for webRequest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
   ],
   "background": {
     "scripts": ["background.js"],
-    "persistent": false
+    "persistent": true
   },
   "browser_action": {
     "default_popup": "popup.html",


### PR DESCRIPTION
## Summary
- keep background script persistent to use `webRequest` API

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68492c7e76c4832a994d128f8cbdd5dc